### PR TITLE
rolled back nestjs/testing version for compatibility

### DIFF
--- a/social-middleware/package.json
+++ b/social-middleware/package.json
@@ -47,7 +47,7 @@
     "@eslint/js": "^9.31.0",
     "@nestjs/cli": "^11.0.7",
     "@nestjs/schematics": "^11.0.0",
-    "@nestjs/testing": "^11.0.1",
+    "@nestjs/testing": "^10.4.4",
     "@swc/cli": "^0.6.0",
     "@swc/core": "^1.10.7",
     "@types/cookie-parser": "^1.4.9",


### PR DESCRIPTION
Rollbacked nestjs testing to resolve npm build error:

chridodd@netwon:~/social-middleware/social-middleware$ sudo docker build .
[+] Building 3.1s (8/10)                                                                                                                docker:default
 => [internal] load build definition from Dockerfile                                                                                              0.0s
 => => transferring dockerfile: 540B                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/node:22-alpine                                                                                 0.3s
 => [internal] load .dockerignore                                                                                                                 0.0s
 => => transferring context: 2B                                                                                                                   0.0s
 => [1/6] FROM docker.io/library/node:22-alpine@sha256:5539840ce9d013fa13e3b9814c9353024be7ac75aca5db6d039504a56c04ea59                           0.0s
 => [internal] load build context                                                                                                                 0.0s
 => => transferring context: 3.54kB                                                                                                               0.0s
 => CACHED [2/6] WORKDIR /app                                                                                                                     0.0s
 => CACHED [3/6] COPY package*.json ./                                                                                                            0.0s
 => ERROR [4/6] RUN npm install                                                                                                                   2.6s
------
 > [4/6] RUN npm install:
2.504 npm error code ERESOLVE
2.513 npm error ERESOLVE unable to resolve dependency tree
2.513 npm error
2.513 npm error While resolving: social-middleware@0.0.1
2.513 npm error Found: @nestjs/common@10.4.20
2.513 npm error node_modules/@nestjs/common
2.513 npm error   @nestjs/common@"^10.4.4" from the root project
2.513 npm error
2.513 npm error Could not resolve dependency:
2.513 npm error peer @nestjs/common@"^11.0.0" from @nestjs/testing@11.1.5
2.513 npm error node_modules/@nestjs/testing
2.513 npm error   dev @nestjs/testing@"^11.0.1" from the root project
2.513 npm error
2.513 npm error Fix the upstream dependency conflict, or retry
2.513 npm error this command with --force or --legacy-peer-deps
2.513 npm error to accept an incorrect (and potentially broken) dependency resolution.
2.513 npm error
2.513 npm error
2.513 npm error For a full report see:
2.513 npm error /root/.npm/_logs/2025-07-29T15_48_22_332Z-eresolve-report.txt
2.513 npm notice
2.513 npm notice New major version of npm available! 10.9.2 -> 11.5.1
2.513 npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.5.1
2.513 npm notice To update run: npm install -g npm@11.5.1
2.513 npm notice
2.513 npm error A complete log of this run can be found in: /root/.npm/_logs/2025-07-29T15_48_22_332Z-debug-0.log
------
Dockerfile:11
--------------------
   9 |
  10 |     # Install the dependencies
  11 | >>> RUN npm install
  12 |
  13 |     # Copy the rest of the application files
--------------------
ERROR: failed to solve: process "/bin/sh -c npm install" did not complete successfully: exit code: 1
