### PR TITLE
Upstream siebel authentication on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The middleware requires a MongoDB database to store user data, applications, and
 ### Option 1: Local MongoDB Installation
 
 1. **Install MongoDB Community Edition**:
-   - **macOS**: `brew install mongodb-community`
+   - **macOS**: `brew tap mongodb/brew && brew install mongodb-community`
    - **Ubuntu/Debian**: Follow [MongoDB Ubuntu installation guide](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/)
    - **Windows**: Download from [MongoDB Download Center](https://www.mongodb.com/try/download/community)
 

--- a/social-middleware/.env.example
+++ b/social-middleware/.env.example
@@ -15,13 +15,14 @@ VITE_BCSC_CLIENT_ID=test-id
 VITE_BCSC_AUTHORITY=test-authority
 
 # Siebel OAuth Configuration
-  SIEBEL_AUTH_URL=your-value
-  SIEBEL_TOKEN_URL=your-value
-  SIEBEL_CLIENT_ID=your-value
-  SIEBEL_APS_BASE_URL=your-value
-  SIEBEL_TRUSTED_USERNAME=your-value
-  OAUTH_REDIRECT_URI=your-value
-  OAUTH_SCOPE=your-value
+SIEBEL_AUTH_URL=your-value
+SIEBEL_TOKEN_URL=your-value
+SIEBEL_CLIENT_ID=your-value
+SIEBEL_CLIENT_SECRET=your-value
+SIEBEL_APS_BASE_URL=your-value
+SIEBEL_TRUSTED_USERNAME=your-value
+OAUTH_REDIRECT_URI=your-value
+OAUTH_SCOPE=your-value
 
-  CASE_CONTACTS_ENDPOINT=your-value
-  SERVICE_REQUESTS_ENDPOINT=your-value
+CASE_CONTACTS_ENDPOINT=your-value
+SERVICE_REQUESTS_ENDPOINT=your-value

--- a/social-middleware/package-lock.json
+++ b/social-middleware/package-lock.json
@@ -19,6 +19,7 @@
         "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/mongoose": "^10.1.0",
         "@nestjs/platform-express": "^10.4.4",
+        "@nestjs/schedule": "^6.0.0",
         "@nestjs/swagger": "^7.4.2",
         "axios": "^1.10.0",
         "bull": "^4.16.5",
@@ -3066,6 +3067,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.0.0.tgz",
+      "integrity": "sha512-aQySMw6tw2nhitELXd3EiRacQRgzUKD9mFcUZVOJ7jPLqIBvXOyvRWLsK9SdurGA+jjziAlMef7iB5ZEFFoQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.3.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.7",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.7.tgz",
@@ -3888,6 +3902,12 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -5189,9 +5209,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -6250,6 +6270,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cron": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.3.0.tgz",
+      "integrity": "sha512-ciiYNLfSlF9MrDqnbMdRWFiA6oizSF7kA1osPP9lRzNu0Uu+AWog1UKy7SkckiDY2irrNjeO6qLyKnXC8oxmrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.6.0",
+        "luxon": "~3.6.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      }
+    },
     "node_modules/cron-parser": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
@@ -6260,6 +6293,15 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cron/node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/cross-spawn": {

--- a/social-middleware/package.json
+++ b/social-middleware/package.json
@@ -30,6 +30,7 @@
     "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/mongoose": "^10.1.0",
     "@nestjs/platform-express": "^10.4.4",
+    "@nestjs/schedule": "^6.0.0",
     "@nestjs/swagger": "^7.4.2",
     "axios": "^1.10.0",
     "bull": "^4.16.5",

--- a/social-middleware/src/app.module.ts
+++ b/social-middleware/src/app.module.ts
@@ -13,6 +13,7 @@ import { ContactModule } from './contact/contact.module';
 import { HouseholdModule } from './household/household.module';
 import { BullDashboardModule } from './bull-dashboard/bull-dashboard.module';
 import { SiebelModule } from './siebel/siebel.module';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({})
 export class AppModule {
@@ -27,6 +28,7 @@ export class AppModule {
         }),
         HttpModule,
         AuthModule,
+        ScheduleModule.forRoot(),
         LoggerModule.forRootAsync({
           imports: [ConfigModule],
           inject: [ConfigService],

--- a/social-middleware/src/siebel/siebel-auth.service.ts
+++ b/social-middleware/src/siebel/siebel-auth.service.ts
@@ -1,11 +1,13 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { firstValueFrom } from 'rxjs';
 import { AxiosResponse, AxiosError } from 'axios';
+import { Cron, CronExpression, SchedulerRegistry } from '@nestjs/schedule';
 
 @Injectable()
-export class SiebelAuthService {
+export class SiebelAuthService implements OnModuleInit {
+  private hasFirstAuth: boolean = false;
   private accessToken: string | null = null;
   private tokenExpiry: Date | null = null;
 
@@ -14,6 +16,7 @@ export class SiebelAuthService {
   constructor(
     private readonly httpService: HttpService,
     private readonly configService: ConfigService,
+    private readonly schedulerRegistry: SchedulerRegistry,
   ) {}
 
   async getAccessToken(): Promise<string> {
@@ -56,6 +59,7 @@ export class SiebelAuthService {
       this.accessToken = response.data.access_token;
       const expiresIn = response.data.expires_in || 3600;
       this.tokenExpiry = new Date(Date.now() + (expiresIn - 60) * 1000); // Refresh 1 min before expiry
+      this.hasFirstAuth = true;
 
       this.logger.log('Successfully obtained Siebel access token');
       return this.accessToken;
@@ -68,6 +72,35 @@ export class SiebelAuthService {
       this.logger.error({ errorData }, 'Failed to obtain Siebel access token');
 
       throw new Error('Failed to authenticate with Siebel');
+    }
+  }
+
+  @Cron(CronExpression.EVERY_5_MINUTES, { name: 'retrySiebelAuth' })
+  async retryAuth() {
+    if (this.hasFirstAuth === false) {
+      try {
+        this.logger.log(`Retrying Siebel authentication...`);
+        await this.getAccessToken();
+        this.logger.log(`Siebel authentication obtained, cron job will stop.`);
+      } catch {
+        this.logger.warn(
+          `Failed to retrieve Siebel access token. Will periodically retry every 5 minutes.`,
+        );
+        return;
+      }
+    }
+    const job = this.schedulerRegistry.getCronJob('retrySiebelAuth');
+    await job.stop();
+  }
+
+  async onModuleInit() {
+    this.logger.log(`Attempting to obtain initial Siebel authentication...`);
+    try {
+      await this.getAccessToken();
+    } catch {
+      this.logger.warn(
+        `Failed to retrieve Siebel access token on startup. Will periodically retry every 5 minutes.`,
+      );
     }
   }
 }

--- a/social-middleware/src/siebel/siebel.module.ts
+++ b/social-middleware/src/siebel/siebel.module.ts
@@ -6,11 +6,17 @@ import { SiebelService } from './siebel.service';
 import { SiebelApiService } from './siebel-api.service';
 import { SiebelPKCEAuthService } from './siebel-pkce-auth.service';
 import { SiebelPKCEAuthController } from './siebel-pkce-auth.controller';
+import { SiebelAuthService } from './siebel-auth.service';
 
 @Module({
   imports: [HttpModule, ConfigModule],
   controllers: [SiebelController, SiebelPKCEAuthController],
-  providers: [SiebelService, SiebelApiService, SiebelPKCEAuthService],
+  providers: [
+    SiebelService,
+    SiebelApiService,
+    SiebelAuthService,
+    SiebelPKCEAuthService,
+  ],
   exports: [SiebelService, SiebelApiService, SiebelPKCEAuthService],
 })
 export class SiebelModule {}


### PR DESCRIPTION
[Story Link](https://dev.azure.com/bc-icm/Caregiver%20Registry/_workitems/edit/8440/)

This PR uses the client credentials grant to obtain Siebel authentication initially on startup, and on demand thereafter. Note that the environment variable 'SIEBEL_CLIENT_SECRET" will need to be provided in order for this to work.

Also included is a readme update for the MacOS specific local installation process.