### PR TITLE
fix: separate test and prod mongodb resource configuration in helm chart

### DIFF
--- a/social-middleware-helm/templates/mongodb-backup-pvc.yaml
+++ b/social-middleware-helm/templates/mongodb-backup-pvc.yaml
@@ -13,5 +13,5 @@ spec:
   storageClassName: netapp-file-backup
   resources:
     requests:
-      storage: 3Gi
+      storage: 2Gi
 {{- end }}

--- a/social-middleware-helm/templates/mongodb-statefulset.yaml
+++ b/social-middleware-helm/templates/mongodb-statefulset.yaml
@@ -120,20 +120,26 @@ spec:
             - name: mongodb-init-script
               mountPath: /scripts
               readOnly: true
-          resources:
-            {{- if or (hasSuffix "-prod" .Release.Namespace) (hasSuffix "-test" .Release.Namespace) }}
-            limits:
-              memory: {{ .Values.mongodb.prod.resources.limits.memory }}
-            requests:
-              cpu: {{ .Values.mongodb.prod.resources.requests.cpu | quote }}
-              memory: {{ .Values.mongodb.prod.resources.requests.memory }}
-            {{- else }}
-            limits:
-              memory: {{ .Values.mongodb.dev.resources.limits.memory }}
-            requests:
-              cpu: {{ .Values.mongodb.dev.resources.requests.cpu | quote }}
-              memory: {{ .Values.mongodb.dev.resources.requests.memory }}
-            {{- end }}
+          resources:                                                                                     
+              {{- if hasSuffix "-prod" .Release.Namespace }}
+              limits:                                                                                      
+                memory: {{ .Values.mongodb.prod.resources.limits.memory }}                               
+              requests:                                                   
+                cpu: {{ .Values.mongodb.prod.resources.requests.cpu | quote }}
+                memory: {{ .Values.mongodb.prod.resources.requests.memory }}  
+              {{- else if hasSuffix "-test" .Release.Namespace }}                                          
+              limits:                                            
+                memory: {{ .Values.mongodb.test.resources.limits.memory }}                                 
+              requests:                                                                                  
+                cpu: {{ .Values.mongodb.test.resources.requests.cpu | quote }}                             
+                memory: {{ .Values.mongodb.test.resources.requests.memory }}  
+              {{- else }}                                                                                  
+              limits:                                                                                    
+                memory: {{ .Values.mongodb.dev.resources.limits.memory }}
+              requests:                                                                                    
+                cpu: {{ .Values.mongodb.dev.resources.requests.cpu | quote }}
+                memory: {{ .Values.mongodb.dev.resources.requests.memory }}                                
+              {{- end }} 
       restartPolicy: Always
       volumes:
         - name: mongodb-tls
@@ -163,8 +169,10 @@ spec:
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            {{- if or (hasSuffix "-prod" .Release.Namespace) (hasSuffix "-test" .Release.Namespace) }}
+            {{- if hasSuffix "-prod" .Release.Namespace }}
             storage: {{ .Values.mongodb.prod.storage.size }}
+            {{- else if hasSuffix "-test" .Release.Namespace }}
+            storage: {{ .Values.mongodb.test.storage.size }}                                             
             {{- else }}
-            storage: {{ .Values.mongodb.dev.storage.size }}
-            {{- end }}
+            storage: {{ .Values.mongodb.dev.storage.size }}                                              
+            {{- end }}  

--- a/social-middleware-helm/values.yaml
+++ b/social-middleware-helm/values.yaml
@@ -43,6 +43,16 @@ mongodb:
         memory: 128Mi
     storage:
       size: 700Mi
+  test:
+    resources:
+      limits:
+        cpu: "500m"
+        memory: 1536Mi
+      requests:
+        cpu: "100m"
+        memory: 512Mi
+    storage:
+      size: 1Gi
   prod:
     resources:
       limits:
@@ -52,7 +62,7 @@ mongodb:
         cpu: "100m"
         memory: 512Mi
     storage:
-      size: 3Gi
+      size: 1Gi
 
 redis:
   replicas: 3


### PR DESCRIPTION
  Adds a dedicated test values block for mongodb to prevent test deployments                               
  from using prod storage sizes, which was causing helm upgrade failures due
  to immutable StatefulSet fields and storage quota limits. 