### PR TITLE
fix: revert mongodb prod storage to match existing PVCs

### DIFF
--- a/social-middleware-helm/templates/mongodb-backup-pvc.yaml
+++ b/social-middleware-helm/templates/mongodb-backup-pvc.yaml
@@ -13,5 +13,9 @@ spec:
   storageClassName: netapp-file-backup
   resources:
     requests:
+      {{- if hasSuffix "-prod" .Release.Namespace }}
+      storage: 3Gi
+      {{- else }}
       storage: 2Gi
+      {{- end }}
 {{- end }}

--- a/social-middleware-helm/values.yaml
+++ b/social-middleware-helm/values.yaml
@@ -62,7 +62,7 @@ mongodb:
         cpu: "100m"
         memory: 512Mi
     storage:
-      size: 1Gi
+      size: 3Gi
 
 redis:
   replicas: 3


### PR DESCRIPTION
PR #219 reduced mongodb.prod.storage.size to 1Gi and mongodb-backup PVC to 2Gi, but prod PVCs are already provisioned at 3Gi. Kubernetes forbids reducing PVC storage and patching StatefulSet volumeClaimTemplates, causing helm-deploy to fail.