### PR TITLE
fix: exclude MongoDB replica set mode in dev namespace

### DIFF
--- a/social-middleware-helm/templates/mongodb-statefulset.yaml
+++ b/social-middleware-helm/templates/mongodb-statefulset.yaml
@@ -80,8 +80,10 @@ spec:
             - containerPort: {{ .Values.mongodb.port }}
               protocol: TCP
           env:
+            {{- if or (hasSuffix "-prod" .Release.Namespace) (hasSuffix "-test" .Release.Namespace) }}
             - name: REPLICA_SET_NAME
               value: "rs0"
+            {{- end }}
             - name: NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## Summary
- `REPLICA_SET_NAME` was unconditionally set to `rs0` for all namespaces after a revert of PR #224
- In dev, the `mongodb-keyfile` is never mounted (correctly guarded by namespace suffix), so MongoDB crashed with `Unable to acquire security key[s]`
- Restores the `{{- if or (hasSuffix "-prod" ...) (hasSuffix "-test" ...) }}` guard around `REPLICA_SET_NAME` so dev runs in standalone mode

## Test plan
- [ ] MongoDB pod in `f6e00d-dev` recovers from CrashLoopBackOff after deploy
- [ ] MongoDB pods in `f6e00d-test` and `f6e00d-prod` are unaffected (still running 3-node replica set)