### PR TITLE
sync(pipelines): capture live social-middleware pipeline from cluster

### DIFF
--- a/pipelines/pipeline.yaml
+++ b/pipelines/pipeline.yaml
@@ -70,12 +70,71 @@ spec:
       workspaces:
         - name: source
           workspace: shared-data
+    - name: set-env-config
+      params:
+        - name: branchName
+          value: $(params.branchName)
+      runAfter:
+        - generate-id
+      taskSpec:
+        metadata: {}
+        params:
+          - name: branchName
+            type: string
+        results:
+          - name: namespace
+            type: string
+          - name: imageTag
+            type: string
+        spec: null
+        steps:
+          - computeResources: {}
+            env:
+              - name: BRANCH_NAME
+                value: $(params.branchName)
+              - name: NAMESPACE_PATH
+                value: $(results.namespace.path)
+              - name: IMAGE_TAG_PATH
+                value: $(results.imageTag.path)
+            image: registry.access.redhat.com/ubi9/ubi-minimal
+            name: set-namespace-and-tag
+            script: |
+              #!/bin/bash
+              set -euxo pipefail
+
+              echo "DEBUG: branchName param = '${BRANCH_NAME}'"
+
+              # Clear any previous values
+              : > "${NAMESPACE_PATH}"
+              : > "${IMAGE_TAG_PATH}"
+
+              case "${BRANCH_NAME}" in
+                dev|develop)
+                  echo -n "f6e00d-dev" > "${NAMESPACE_PATH}"
+                  echo -n "dev" > "${IMAGE_TAG_PATH}"
+                  ;;
+                test)
+                  echo -n "f6e00d-test" > "${NAMESPACE_PATH}"
+                  echo -n "test" > "${IMAGE_TAG_PATH}"
+                  ;;
+                main|prod)
+                  echo -n "f6e00d-prod" > "${NAMESPACE_PATH}"
+                  echo -n "prod" > "${IMAGE_TAG_PATH}"
+                  ;;
+                *)
+                  echo "ERROR: Unknown branch '${BRANCH_NAME}'"
+                  exit 1
+                  ;;
+              esac
+
+              echo "DEBUG: resolved namespace = '$(cat "${NAMESPACE_PATH}")'"
+              echo "DEBUG: resolved imageTag  = '$(cat "${IMAGE_TAG_PATH}")'"
     - name: buildah
       params:
         - name: IMAGE
           value: $(params.imageUrl)
         - name: IMAGE_TAG
-          value: $(params.branchName)
+          value: $(tasks.set-env-config.results.imageTag)
         - name: IMAGE_REGISTRY
           value: $(params.imageRegistry)
         - name: IMAGE_REGISTRY_USER
@@ -89,7 +148,7 @@ spec:
         - name: BUILDAH_IMAGE
           value: $(params.buildahImage)
       runAfter:
-        - generate-id
+        - set-env-config
       taskRef:
         kind: Task
         name: buildah
@@ -109,7 +168,9 @@ spec:
         - name: IMAGE
           value: $(params.imageUrl)
         - name: IMAGE_TAG
-          value: $(params.branchName)
+          value: $(tasks.set-env-config.results.imageTag)
+        - name: NAMESPACE
+          value: $(tasks.set-env-config.results.namespace)
       runAfter:
         - buildah
       taskRef:
@@ -128,7 +189,7 @@ spec:
         - name: deploymentName
           value: $(params.deploymentName)
         - name: namespace
-          value: $(params.branchName)
+          value: $(tasks.set-env-config.results.namespace)
   workspaces:
     - description: |
         This workspace will receive the cloned git repo and be passed


### PR DESCRIPTION
## Problem

The in-repo `pipelines/pipeline.yaml` had drifted well behind the pipeline actually running in `f6e00d-tools`.

The live pipeline has a `set-env-config` task that maps `branchName` to **both** a target namespace and an image tag:

| branch | namespace | image tag |
|---|---|---|
| `dev` / `develop` | `f6e00d-dev` | `dev` |
| `test` | `f6e00d-test` | `test` |
| `main` / `prod` | `f6e00d-prod` | `prod` |

and feeds those results into `buildah`, `helm-deploy` and `reroll-deployment`. None of that existed in the committed file.

Applying the repo version would have regressed the pipeline — most visibly `reroll-deployment`, which still passed a bare branch name (`dev`, `main`) as a namespace rather than `f6e00d-*`.

## Change

Captured verbatim from the cluster. The committed `spec` is now identical to the live object, verified by parsing both and comparing.

**No behavioural change to the running pipeline** — this only stops the repo from being able to undo config that currently exists only in the cluster.

## Context

Companion to the `helm-deploy` namespace fix. That incident traced back to a working config living only in the cluster while the repo carried an older, broken version; this closes the same gap for the pipeline itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)