### PR TITLE
fix(pipelines): stop the Docker Hub rate limit breaking builds

### DIFF
--- a/pipelines/pipeline-tasks-helm/templates/buildah.yaml
+++ b/pipelines/pipeline-tasks-helm/templates/buildah.yaml
@@ -79,7 +79,7 @@ spec:
           mountPath: /var/lib/containers
 
     - name: trivy-scan
-      image: docker.io/aquasec/trivy
+      image: ghcr.io/aquasecurity/trivy:0.69.3
       script: |
         trivy image $(params.IMAGE_REGISTRY)/$(params.IMAGE):$(params.IMAGE_TAG)
       workingDir: $(workspaces.source.path)

--- a/pipelines/pipeline-tasks-helm/templates/generate-id.yaml
+++ b/pipelines/pipeline-tasks-helm/templates/generate-id.yaml
@@ -18,7 +18,7 @@ spec:
       type: string
   steps:
     - name: generate
-      image: alpine/git:latest
+      image: alpine/git:2.54.0
       script: |
         #!/bin/sh
 

--- a/pipelines/pipeline-tasks-helm/templates/git-clone.yaml
+++ b/pipelines/pipeline-tasks-helm/templates/git-clone.yaml
@@ -80,9 +80,10 @@ spec:
     - name: gitInitImage
       description: The image providing the git-init binary that this Task runs.
       type: string
-      # default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.21.0"
-      default: "docker.io/michaelin/github-cli:v2.0.0"
-      # default: "alpine/git:v2.26.2"
+      # The script uses plain `git` with the PAT in the clone URL, so this only
+      # needs a git binary -- no GitHub CLI. Pinned so the implied
+      # imagePullPolicy is IfNotPresent rather than Always.
+      default: "alpine/git:2.54.0"
     - name: userHome
       description: |
         Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden
@@ -137,13 +138,6 @@ spec:
       script: |
         #!/usr/bin/env sh
 
-        # git login
-        echo "GH CLI Auth"
-        echo $PARAM_GITHUB_PAT > token.txt
-        gh auth login --with-token < token.txt
-        rm token.txt
-        gh auth status
-
         cleandir() {
           # Delete any existing contents of the repo directory if it exists.
           #
@@ -170,7 +164,10 @@ spec:
         # echo ${PARAM_REVISION}
 
         # NOTE that if we use PAT, the url must be HTTPS not ssh
-        gh repo clone ${PARAM_URL} ${CHECKOUT_DIR} -- --branch ${PARAM_REVISION}
+        git clone https://x-access-token:${PARAM_GITHUB_PAT}@${PARAM_URL#https://} \
+          "${CHECKOUT_DIR}" \
+           --branch "${PARAM_REVISION}" \
+           --depth "${PARAM_DEPTH}"
 
         cd "${CHECKOUT_DIR}"
         RESULT_SHA="$(git rev-parse HEAD)"

--- a/pipelines/pipeline-tasks-helm/templates/git-clone.yaml
+++ b/pipelines/pipeline-tasks-helm/templates/git-clone.yaml
@@ -81,7 +81,7 @@ spec:
       description: The image providing the git-init binary that this Task runs.
       type: string
       # default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.21.0"
-      default: "docker.io/michaelin/github-cli:latest"
+      default: "docker.io/michaelin/github-cli:v2.0.0"
       # default: "alpine/git:v2.26.2"
     - name: userHome
       description: |
@@ -169,7 +169,7 @@ spec:
         # echo ${CHECKOUT_DIR}
         # echo ${PARAM_REVISION}
 
-        NOTE that if we use PAT, the url must be HTTPS not ssh
+        # NOTE that if we use PAT, the url must be HTTPS not ssh
         gh repo clone ${PARAM_URL} ${CHECKOUT_DIR} -- --branch ${PARAM_REVISION}
 
         cd "${CHECKOUT_DIR}"

--- a/pipelines/pipeline-tasks-helm/templates/rerolledeployment.yaml
+++ b/pipelines/pipeline-tasks-helm/templates/rerolledeployment.yaml
@@ -15,7 +15,7 @@ spec:
       type: string
   steps:
     - name: reroll-deployment
-      image: 'openshift/origin-cli:latest' 
+      image: 'quay.io/openshift/origin-cli:4.18'
       script: |
         #!/bin/bash
         echo "Re-rolling deployment: $(params.deploymentName) in namespace: $(params.namespace)"


### PR DESCRIPTION
The build pipeline was failing at `git-clone`:

```
toomanyrequests: You have reached your unauthenticated pull rate limit
```

## Why it happened

No `imagePullPolicy` is set on any task, so Kubernetes infers it from the tag. Four task images used `:latest` or no tag at all, giving them an implied policy of `Always` — every run re-pulled them from Docker Hub, spending quota metered against the cluster's shared egress IP rather than ours. Nothing in the pipeline changed; the anonymous tier got tighter and we lost the lottery against the other Gold tenants.

## What changed

| Task | Before | After |
|---|---|---|
| `buildah` trivy-scan | `docker.io/aquasec/trivy` | `ghcr.io/aquasecurity/trivy:0.69.3` |
| `generate-id` | `alpine/git:latest` | `alpine/git:2.54.0` |
| `git-clone` | `michaelin/github-cli:latest` | `alpine/git:2.54.0` |
| `reroll-deployment` | `openshift/origin-cli:latest` | `quay.io/openshift/origin-cli:4.18` |

Pinning flips the implied policy to `IfNotPresent`, so these cache on the node instead of re-pulling. trivy also moves to GHCR (upstream org, no Docker Hub limit) at the same version the live task already ran. origin-cli moves to quay.io — the Docker Hub `openshift` org has been unmaintained since the 3.11 era — on the tag matching our server, 4.18.41.

`buildah` itself was already on `quay.io/buildah/stable:v1.39.3`, which is why it never hit this.

## The git-clone rewrite

The chart still used `gh auth login` / `gh repo clone`, but the task **running in the cluster** was rewritten some time ago to use plain `git clone` with the PAT in the URL, and that was never committed. Deploying this chart as it stood would have reverted the cluster to the gh version. This brings the chart in line with what actually runs — and with plain git the step only needs a git binary, which is what lets us retire `michaelin/github-cli`, a five-year-old image from a personal Docker Hub account that sat on the critical path of every build.

Also comments out a bare line of prose in the script that was being executed as a shell command. It failed harmlessly (no `set -e`) but wrote an error into every clone log.

## Verification

- Standalone TaskRun against the live `git-clone`: cloned `bcgov/social-middleware` at `666a6e9` on `alpine/git:2.54.0` in 17s, both results populated.
- Full pipeline run `pipeline-build-run-8a3qwq`: **succeeded**, ~2 min, all six tasks.
- Chart rendered and diffed against every live Task; only remaining differences are Tekton's `v1beta1` → `v1` defaulting.

Already deployed to `f6e00d-tools` as `tasks` release revision 13, so the cluster is running this. Merging closes the gap between git and the cluster.

## Note on the base

Targeted at `dev`, which already has the `helm-deploy` NAMESPACE fix (#269) and the synced `pipeline.yaml` (#270) — this is complementary and doesn't touch either.

`main` has neither those PRs nor this one, so **`main` still renders a `helm-deploy` without `NAMESPACE`**. Anyone deploying the chart from `main` sends deployments to a namespace derived from the branch name. Worth promoting dev → test → main sooner rather than later.

## Not included

`pipelines/pipeline.yaml` on this branch still has an unpinned `registry.access.redhat.com/ubi9/ubi-minimal` in the `set-env-config` inline taskSpec. It re-pulls every run, but Red Hat's registry doesn't rate-limit, so it is a reproducibility issue rather than a quota one. Left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)