### PR TITLE
promote(pipelines): test -> main

### DIFF
--- a/pipelines/pipeline-tasks-helm/templates/buildah.yaml
+++ b/pipelines/pipeline-tasks-helm/templates/buildah.yaml
@@ -79,7 +79,7 @@ spec:
           mountPath: /var/lib/containers
 
     - name: trivy-scan
-      image: docker.io/aquasec/trivy
+      image: ghcr.io/aquasecurity/trivy:0.69.3
       script: |
         trivy image $(params.IMAGE_REGISTRY)/$(params.IMAGE):$(params.IMAGE_TAG)
       workingDir: $(workspaces.source.path)

--- a/pipelines/pipeline-tasks-helm/templates/generate-id.yaml
+++ b/pipelines/pipeline-tasks-helm/templates/generate-id.yaml
@@ -18,7 +18,7 @@ spec:
       type: string
   steps:
     - name: generate
-      image: alpine/git:latest
+      image: alpine/git:2.54.0
       script: |
         #!/bin/sh
 

--- a/pipelines/pipeline-tasks-helm/templates/git-clone.yaml
+++ b/pipelines/pipeline-tasks-helm/templates/git-clone.yaml
@@ -80,9 +80,10 @@ spec:
     - name: gitInitImage
       description: The image providing the git-init binary that this Task runs.
       type: string
-      # default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.21.0"
-      default: "docker.io/michaelin/github-cli:v2.0.0"
-      # default: "alpine/git:v2.26.2"
+      # The script uses plain `git` with the PAT in the clone URL, so this only
+      # needs a git binary -- no GitHub CLI. Pinned so the implied
+      # imagePullPolicy is IfNotPresent rather than Always.
+      default: "alpine/git:2.54.0"
     - name: userHome
       description: |
         Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden
@@ -137,13 +138,6 @@ spec:
       script: |
         #!/usr/bin/env sh
 
-        # git login
-        echo "GH CLI Auth"
-        echo $PARAM_GITHUB_PAT > token.txt
-        gh auth login --with-token < token.txt
-        rm token.txt
-        gh auth status
-
         cleandir() {
           # Delete any existing contents of the repo directory if it exists.
           #
@@ -170,7 +164,10 @@ spec:
         # echo ${PARAM_REVISION}
 
         # NOTE that if we use PAT, the url must be HTTPS not ssh
-        gh repo clone ${PARAM_URL} ${CHECKOUT_DIR} -- --branch ${PARAM_REVISION}
+        git clone https://x-access-token:${PARAM_GITHUB_PAT}@${PARAM_URL#https://} \
+          "${CHECKOUT_DIR}" \
+           --branch "${PARAM_REVISION}" \
+           --depth "${PARAM_DEPTH}"
 
         cd "${CHECKOUT_DIR}"
         RESULT_SHA="$(git rev-parse HEAD)"

--- a/pipelines/pipeline-tasks-helm/templates/git-clone.yaml
+++ b/pipelines/pipeline-tasks-helm/templates/git-clone.yaml
@@ -81,7 +81,7 @@ spec:
       description: The image providing the git-init binary that this Task runs.
       type: string
       # default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.21.0"
-      default: "docker.io/michaelin/github-cli:latest"
+      default: "docker.io/michaelin/github-cli:v2.0.0"
       # default: "alpine/git:v2.26.2"
     - name: userHome
       description: |
@@ -169,7 +169,7 @@ spec:
         # echo ${CHECKOUT_DIR}
         # echo ${PARAM_REVISION}
 
-        NOTE that if we use PAT, the url must be HTTPS not ssh
+        # NOTE that if we use PAT, the url must be HTTPS not ssh
         gh repo clone ${PARAM_URL} ${CHECKOUT_DIR} -- --branch ${PARAM_REVISION}
 
         cd "${CHECKOUT_DIR}"

--- a/pipelines/pipeline-tasks-helm/templates/helm-deploy.yaml
+++ b/pipelines/pipeline-tasks-helm/templates/helm-deploy.yaml
@@ -23,6 +23,9 @@ spec:
     - description: Name of image tag.
       name: IMAGE_TAG
       type: string
+    - description: Target namespace for deployment.
+      name: NAMESPACE
+      type: string
     - default: 'docker.io/lachlanevenson/k8s-helm:v3.10.2'
       description: Specify a specific helm image
       name: HELM_IMAGE
@@ -32,7 +35,7 @@ spec:
       name: helm-deploy
       resources: {}
       script: |
-        /usr/local/bin/helm upgrade --install $(params.HELM_RELEASE) --set image.tag=$(params.IMAGE_TAG) -f $(params.HELM_DIR)/$(params.HELM_VALUES) $(params.HELM_DIR) --namespace f6e00d-$(params.IMAGE_TAG)
+        /usr/local/bin/helm upgrade --install $(params.HELM_RELEASE) --set image.tag=$(params.IMAGE_TAG) -f $(params.HELM_DIR)/$(params.HELM_VALUES) $(params.HELM_DIR) --namespace $(params.NAMESPACE)
       workingDir: $(workspaces.source.path)
   workspaces:
     - name: source

--- a/pipelines/pipeline-tasks-helm/templates/rerolledeployment.yaml
+++ b/pipelines/pipeline-tasks-helm/templates/rerolledeployment.yaml
@@ -15,7 +15,7 @@ spec:
       type: string
   steps:
     - name: reroll-deployment
-      image: 'openshift/origin-cli:latest' 
+      image: 'quay.io/openshift/origin-cli:4.18'
       script: |
         #!/bin/bash
         echo "Re-rolling deployment: $(params.deploymentName) in namespace: $(params.namespace)"

--- a/pipelines/pipeline.yaml
+++ b/pipelines/pipeline.yaml
@@ -70,12 +70,71 @@ spec:
       workspaces:
         - name: source
           workspace: shared-data
+    - name: set-env-config
+      params:
+        - name: branchName
+          value: $(params.branchName)
+      runAfter:
+        - generate-id
+      taskSpec:
+        metadata: {}
+        params:
+          - name: branchName
+            type: string
+        results:
+          - name: namespace
+            type: string
+          - name: imageTag
+            type: string
+        spec: null
+        steps:
+          - computeResources: {}
+            env:
+              - name: BRANCH_NAME
+                value: $(params.branchName)
+              - name: NAMESPACE_PATH
+                value: $(results.namespace.path)
+              - name: IMAGE_TAG_PATH
+                value: $(results.imageTag.path)
+            image: registry.access.redhat.com/ubi9/ubi-minimal
+            name: set-namespace-and-tag
+            script: |
+              #!/bin/bash
+              set -euxo pipefail
+
+              echo "DEBUG: branchName param = '${BRANCH_NAME}'"
+
+              # Clear any previous values
+              : > "${NAMESPACE_PATH}"
+              : > "${IMAGE_TAG_PATH}"
+
+              case "${BRANCH_NAME}" in
+                dev|develop)
+                  echo -n "f6e00d-dev" > "${NAMESPACE_PATH}"
+                  echo -n "dev" > "${IMAGE_TAG_PATH}"
+                  ;;
+                test)
+                  echo -n "f6e00d-test" > "${NAMESPACE_PATH}"
+                  echo -n "test" > "${IMAGE_TAG_PATH}"
+                  ;;
+                main|prod)
+                  echo -n "f6e00d-prod" > "${NAMESPACE_PATH}"
+                  echo -n "prod" > "${IMAGE_TAG_PATH}"
+                  ;;
+                *)
+                  echo "ERROR: Unknown branch '${BRANCH_NAME}'"
+                  exit 1
+                  ;;
+              esac
+
+              echo "DEBUG: resolved namespace = '$(cat "${NAMESPACE_PATH}")'"
+              echo "DEBUG: resolved imageTag  = '$(cat "${IMAGE_TAG_PATH}")'"
     - name: buildah
       params:
         - name: IMAGE
           value: $(params.imageUrl)
         - name: IMAGE_TAG
-          value: $(params.branchName)
+          value: $(tasks.set-env-config.results.imageTag)
         - name: IMAGE_REGISTRY
           value: $(params.imageRegistry)
         - name: IMAGE_REGISTRY_USER
@@ -89,7 +148,7 @@ spec:
         - name: BUILDAH_IMAGE
           value: $(params.buildahImage)
       runAfter:
-        - generate-id
+        - set-env-config
       taskRef:
         kind: Task
         name: buildah
@@ -109,7 +168,9 @@ spec:
         - name: IMAGE
           value: $(params.imageUrl)
         - name: IMAGE_TAG
-          value: $(params.branchName)
+          value: $(tasks.set-env-config.results.imageTag)
+        - name: NAMESPACE
+          value: $(tasks.set-env-config.results.namespace)
       runAfter:
         - buildah
       taskRef:
@@ -128,7 +189,7 @@ spec:
         - name: deploymentName
           value: $(params.deploymentName)
         - name: namespace
-          value: $(params.branchName)
+          value: $(tasks.set-env-config.results.namespace)
   workspaces:
     - description: |
         This workspace will receive the cloned git repo and be passed


### PR DESCRIPTION
Final step of the pipeline fix promotion. `dev` → `test` (#273) is merged and its build passed; this brings `main` current.

## Why this one matters most

`main` is the only branch still rendering the old chart:

```
origin/dev    git-clone image: alpine/git:2.54.0
origin/test   git-clone image: alpine/git:2.54.0
origin/main   git-clone image: docker.io/michaelin/github-cli:latest   <-- stale
```

`main` also still has a `helm-deploy` without `NAMESPACE`, hardcoding `--namespace f6e00d-$(params.IMAGE_TAG)`. Anyone deploying the tasks chart from `main` today sends deployments to a namespace derived from the branch name, and reverts the cluster to the GitHub-CLI clone step. The cluster has been running the corrected chart since `tasks` revision 13 — this closes the last gap between git and production.

## What it carries

Verified with `git merge-tree`: the merge changes **exactly six files, all under `pipelines/`**.

```
pipelines/pipeline.yaml
pipelines/pipeline-tasks-helm/templates/buildah.yaml
pipelines/pipeline-tasks-helm/templates/generate-id.yaml
pipelines/pipeline-tasks-helm/templates/git-clone.yaml
pipelines/pipeline-tasks-helm/templates/helm-deploy.yaml
pipelines/pipeline-tasks-helm/templates/rerolledeployment.yaml
```

No application code. `README.md` differs between the branches, but `test` never modified it since the merge base, so `main`’s version is preserved — no revert, no conflict.

Contents: #269 (explicit `NAMESPACE`), #270 (`pipeline.yaml` synced from cluster), #272 (image pins fixing the Docker Hub rate limit, plus the plain-git clone rewrite).

## Deployment effect

**This is a production deployment.** Merging pushes to `main`, which the live trigger matches, so it builds and runs `helm upgrade --install` against `f6e00d-prod` followed by a re-roll of the `social-middleware` deployment.

Because the promotion contains no application code, the build produces functionally identical output and the deploy amounts to a re-roll. Low risk, but worth merging while someone is around to watch it rather than at end of day.

## Track record

Every merge in this sequence has built and deployed green:

| Run | Trigger | Result |
|---|---|---|
| `pipeline-build-run-8a3qwq` | manual verification | Succeeded |
| `pipeline-build-run-j8s6p` | #272 → `dev` | Succeeded |
| `pipeline-build-run-xp78j` | #273 → `test` | Succeeded |

🤖 Generated with [Claude Code](https://claude.com/claude-code)